### PR TITLE
chore: auto-install git and python 3.12.8 in install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -268,7 +268,7 @@ if "%PY_HAVE_GOOD_INSTALLER%"=="0" (
 )
 
 echo     Installing Python %PYTHON_VERSION% silently (per-user)...
-"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=1 Shortcuts=0 AssociateFiles=0 TargetDir="%PYTHON_INSTALL_DIR%"
+"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 InstallLauncherAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=1 Shortcuts=0 AssociateFiles=0 TargetDir="%PYTHON_INSTALL_DIR%"
 if errorlevel 1 ( exit /b 1 )
 if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
 set "PATH=%PYTHON_INSTALL_DIR%;%PATH%"

--- a/install.bat
+++ b/install.bat
@@ -185,7 +185,7 @@ if not exist "%PYTHON_INSTALLER%" (
     if errorlevel 1 ( exit /b 1 )
 )
 echo     Installing Python %PYTHON_VERSION% silently (per-user)...
-"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Shortcuts=0 AssociateFiles=0 InstallDir="%PYTHON_INSTALL_DIR%"
+"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=1 Shortcuts=0 AssociateFiles=0 TargetDir="%PYTHON_INSTALL_DIR%"
 if errorlevel 1 ( exit /b 1 )
 if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
 :: make python available to this session (and to the app) immediately

--- a/install.bat
+++ b/install.bat
@@ -98,7 +98,11 @@ if errorlevel 1 (
 )
 
 :run_setup
-cd /d "%INSTALL_DIR%"
+cd /d "%INSTALL_DIR%" || (
+    echo [x] Failed to enter "%INSTALL_DIR%".
+    pause
+    exit /b 1
+)
 echo.
 echo [*] Running setup.py...
 "%PY_CMD%" setup.py

--- a/install.bat
+++ b/install.bat
@@ -1,30 +1,30 @@
 @echo off
-setlocal EnableDelayedExpansion
+setlocal EnableExtensions EnableDelayedExpansion
 
-title owo-dusk Installer
+title OwO-Dusk Installer
 
 echo.
-echo  owo-dusk Installer - Windows
+echo  OwO-Dusk Installer - Windows
 echo  ==============================
 echo.
 
 set "OWO_REPO_URL=https://github.com/owo-dusk/owo-dusk.git"
 set "INSTALL_DIR=%USERPROFILE%\Desktop\owo-dusk"
 
-set "GIT_VERSION=2.55.0.windows.3"
-set "GIT_PORTABLE_ASSET=PortableGit-2.55.0.3-64-bit.7z.exe"
+set "GIT_VERSION=2.55.0.windows.5"
+set "GIT_PORTABLE_ASSET=PortableGit-2.55.0.5-64-bit.7z.exe"
 set "GIT_INSTALL_DIR=%LocalAppData%\Programs\Git"
 set "GIT_CMD="
+set "GIT_SHA256=5aa8a20f6e9abb2c755f0e73c91c687701a46b309ad84a0ca6509380fa4ae290"
 
-set "PYTHON_VERSION=3.12.8"
-set "PYTHON_INSTALL_DIR=%LocalAppData%\Programs\Python\Python312"
+set "PYTHON_VERSION=3.13.15"
+set "MIN_PYTHON_VERSION=3.12"
+set "PYTHON_INSTALL_DIR=%LocalAppData%\Programs\Python\Python313"
+set "PYTHON_SHA256=edec09c4853aeae9ac36efb8c9f95b6b8e2fee65eee56d9767a8b7c69c574403"
+:: Will be set later
 set "PY_CMD="
 
-:: ---------------------------------------------------------------
-:: 1) Make sure Git is available. An existing install is reused;
-::    otherwise a portable Git is downloaded and extracted silently
-::    (per-user, no admin rights required).
-:: ---------------------------------------------------------------
+
 echo [*] Checking for Git...
 call :find_git
 if errorlevel 1 (
@@ -47,15 +47,10 @@ if errorlevel 1 (
 echo [*] Using Git: "%GIT_CMD%"
 echo.
 
-:: ---------------------------------------------------------------
-:: 2) Make sure Python 3.12 is available. An existing 3.12.x is
-::    reused; otherwise Python %PYTHON_VERSION% is downloaded and
-::    installed silently (per-user, no admin rights required).
-:: ---------------------------------------------------------------
-echo [*] Checking for Python %PYTHON_VERSION%...
+echo [*] Checking for Python %MIN_PYTHON_VERSION%+...
 call :find_python
 if errorlevel 1 (
-    echo [^!] Python %PYTHON_VERSION% not found. Installing it silently...
+    echo [^!] Python %MIN_PYTHON_VERSION%+ not found. Installing Python %PYTHON_VERSION% silently...
     call :install_python
     if errorlevel 1 (
         echo [x] Failed to install Python automatically.
@@ -75,13 +70,18 @@ echo [*] Using Python: "%PY_CMD%"
 "%PY_CMD%" --version
 echo.
 
-:: ---------------------------------------------------------------
-:: 3) Clone (or reuse) the repository
-:: ---------------------------------------------------------------
+:: Clone OwO-Dusk repo.
 if exist "%INSTALL_DIR%" (
     echo [^!] Folder "%INSTALL_DIR%" already exists.
     set /p CONFIRM="    Re-clone and overwrite? [y/N]: "
     if /i "!CONFIRM!"=="y" (
+        echo "%INSTALL_DIR%" | findstr /i "\owo-dusk" >nul 2>&1
+        if errorlevel 1 (
+            echo [x] Safety check failed - install path doesn't look right. Aborting.
+            pause
+            exit /b 1
+        )
+        echo     If owo-dusk is currently running, please close it first.
         rmdir /s /q "%INSTALL_DIR%"
     ) else (
         echo [*] Skipping clone - using existing directory.
@@ -122,15 +122,11 @@ if defined OWO_INSTALLER_SKIP_LAUNCH (
 echo.
 echo -------------------------------------------------------
 echo  To run owo-dusk again next time, open CMD and run:
-echo    cd "%INSTALL_DIR%" ^&^& python uwu.py
+echo    cd "%INSTALL_DIR%" ^&^& "%PY_CMD%" uwu.py
 echo -------------------------------------------------------
 echo.
 pause
 exit /b 0
-
-:: ================================================================
-:: Subroutines
-:: ================================================================
 
 :: Try to locate an existing Git install; sets GIT_CMD on success.
 :find_git
@@ -141,56 +137,153 @@ if exist "%ProgramFiles%\Git\cmd\git.exe" ( set "GIT_CMD=%ProgramFiles%\Git\cmd\
 if exist "%GIT_INSTALL_DIR%\cmd\git.exe" ( set "GIT_CMD=%GIT_INSTALL_DIR%\cmd\git.exe" & set "PATH=%GIT_INSTALL_DIR%\cmd;%PATH%" & exit /b 0 )
 exit /b 1
 
-:: Download and extract a portable Git (no admin rights required).
+:: Install Git if not installed
 :install_git
 set "GIT_INSTALLER=%TEMP%\%GIT_PORTABLE_ASSET%"
-if not exist "%GIT_INSTALLER%" (
+set "GIT_HAVE_GOOD_INSTALLER=0"
+
+if exist "%GIT_INSTALLER%" (
+    call :verify_sha256 "%GIT_INSTALLER%" "%GIT_SHA256%"
+    if not errorlevel 1 set "GIT_HAVE_GOOD_INSTALLER=1"
+)
+
+if "%GIT_HAVE_GOOD_INSTALLER%"=="0" (
     echo     Downloading %GIT_PORTABLE_ASSET%...
     call :download "https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%/%GIT_PORTABLE_ASSET%" "%GIT_INSTALLER%"
     if errorlevel 1 ( exit /b 1 )
+    call :verify_sha256 "%GIT_INSTALLER%" "%GIT_SHA256%"
+    if errorlevel 1 (
+        echo     Downloaded file failed checksum verification - aborting.
+        del /f /q "%GIT_INSTALLER%" >nul 2>&1
+        exit /b 1
+    )
 )
+
 echo     Extracting to "%GIT_INSTALL_DIR%"...
 if not exist "%GIT_INSTALL_DIR%" mkdir "%GIT_INSTALL_DIR%"
 "%GIT_INSTALLER%" -o"%GIT_INSTALL_DIR%" -y >nul 2>&1
 if errorlevel 1 ( exit /b 1 )
 if not exist "%GIT_INSTALL_DIR%\cmd\git.exe" ( exit /b 1 )
-:: make git available to this session (and to pip subprocesses) immediately
+
+:: Update current session PATH
 set "PATH=%GIT_INSTALL_DIR%\cmd;%PATH%"
+
+:: Permanently update User PATH in Windows Registry
+powershell.exe -NoProfile -NonInteractive -Command "$p = [Environment]::GetEnvironmentVariable('PATH', 'User'); if ($p -notlike '*%GIT_INSTALL_DIR%\cmd*') { [Environment]::SetEnvironmentVariable('PATH', '%GIT_INSTALL_DIR%\cmd;' + $p, 'User') }"
+
 exit /b 0
 
-:: Try to locate a usable Python 3.12.x; sets PY_CMD on success.
+:: Attempts to find any python version installed
 :find_python
 set "PY_CMD="
-:: 1) the py launcher, if a 3.12 is registered
-for /f "delims=" %%P in ('py -3.12 -c "import sys;print(sys.executable)" 2^>nul') do set "PY_CMD=%%P"
-if defined PY_CMD ( exit /b 0 )
-:: 2) a bare `python` that is already a 3.12.x
-set "PY_VER="
-for /f "tokens=2 delims= " %%v in ('python --version 2^>^&1') do set "PY_VER=%%v"
-if defined PY_VER (
-    echo !PY_VER! | findstr /b "3.12." >nul 2>&1
-    if not errorlevel 1 ( set "PY_CMD=python" & exit /b 0 )
+
+:: 1) Standard `py` launcher (locates any registered Python, even if off PATH)
+for /f "delims=" %%P in ('py -3 -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%P"
+if defined PY_CMD goto :prompt_add_path
+
+:: 2) Check `python` on PATH (skipping WindowsApps Store execution alias)
+set "PY_WHERE="
+for /f "delims=" %%W in ('where python 2^>nul') do if not defined PY_WHERE set "PY_WHERE=%%W"
+if defined PY_WHERE (
+    echo !PY_WHERE! | findstr /i "WindowsApps" >nul 2>&1
+    if errorlevel 1 (
+        for /f "delims=" %%P in ('python -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=python"
+        if defined PY_CMD exit /b 0
+    )
 )
-:: 3) common install locations
-if exist "%PYTHON_INSTALL_DIR%\python.exe" ( set "PY_CMD=%PYTHON_INSTALL_DIR%\python.exe" & set "PATH=%PYTHON_INSTALL_DIR%;%PATH%" & exit /b 0 )
-if exist "%ProgramFiles%\Python312\python.exe" ( set "PY_CMD=%ProgramFiles%\Python312\python.exe" & set "PATH=%ProgramFiles%\Python312;%PATH%" & exit /b 0 )
+
+:: 3) Check Windows Registry (finds official installs not added to PATH)
+for /f "tokens=2*" %%A in ('reg query "HKCU\Software\Python\PythonCore" /s /v InstallPath 2^>nul ^| findstr /i "REG_SZ"') do (
+    if exist "%%Bpython.exe" (
+        for /f "delims=" %%P in ('"%%Bpython.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%Bpython.exe"
+        if defined PY_CMD goto :prompt_add_path
+    )
+)
+for /f "tokens=2*" %%A in ('reg query "HKLM\Software\Python\PythonCore" /s /v InstallPath 2^>nul ^| findstr /i "REG_SZ"') do (
+    if exist "%%Bpython.exe" (
+        for /f "delims=" %%P in ('"%%Bpython.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%Bpython.exe"
+        if defined PY_CMD goto :prompt_add_path
+    )
+)
+
+:: 4) Fallback: Search standard install folders off PATH
+:: Per-user installation directory (default installer location when non-admin)
+for /d %%D in ("%LOCALAPPDATA%\Programs\Python\Python*") do (
+    if exist "%%D\python.exe" (
+        for /f "delims=" %%P in ('"%%D\python.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%D\python.exe"
+        if defined PY_CMD goto :prompt_add_path
+    )
+)
+:: System-wide installation directories
+for /d %%D in ("%ProgramFiles%\Python*") do (
+    if exist "%%D\python.exe" (
+        for /f "delims=" %%P in ('"%%D\python.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%D\python.exe"
+        if defined PY_CMD goto :prompt_add_path
+    )
+)
+for /d %%D in ("%ProgramFiles(x86)%\Python*") do (
+    if exist "%%D\python.exe" (
+        for /f "delims=" %%P in ('"%%D\python.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%D\python.exe"
+        if defined PY_CMD goto :prompt_add_path
+    )
+)
+
 exit /b 1
 
-:: Download and silently install Python %PYTHON_VERSION% per-user (no admin).
+:prompt_add_path
+for %%I in ("!PY_CMD!") do set "PY_DIR=%%~dpI"
+set "PY_DIR=!PY_DIR:~0,-1!"
+echo !PATH! | findstr /i /c:"!PY_DIR!" >nul 2>&1
+if errorlevel 1 (
+    echo [^!] Found Python at "!PY_CMD!", but its directory is not in PATH.
+    set /p ADD_PATH_CHOICE="    Add "!PY_DIR!" to current session PATH? [y/N]: "
+    if /i "!ADD_PATH_CHOICE!"=="y" (
+        set "PATH=!PY_DIR!;!PATH!"
+        echo [*] Added Python directory to session PATH.
+    )
+)
+exit /b 0
+
+:: Install Python v3.13.15
 :install_python
 set "PYTHON_INSTALLER=%TEMP%\python-%PYTHON_VERSION%-amd64.exe"
-if not exist "%PYTHON_INSTALLER%" (
+set "PY_HAVE_GOOD_INSTALLER=0"
+
+if exist "%PYTHON_INSTALLER%" (
+    call :verify_sha256 "%PYTHON_INSTALLER%" "%PYTHON_SHA256%"
+    if not errorlevel 1 set "PY_HAVE_GOOD_INSTALLER=1"
+)
+
+if "%PY_HAVE_GOOD_INSTALLER%"=="0" (
     echo     Downloading Python %PYTHON_VERSION%...
+    :: https://www.python.org/ftp/python/3.13.15/python-3.13.15-amd64.exe
     call :download "https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-amd64.exe" "%PYTHON_INSTALLER%"
     if errorlevel 1 ( exit /b 1 )
+    call :verify_sha256 "%PYTHON_INSTALLER%" "%PYTHON_SHA256%"
+    if errorlevel 1 (
+        echo     Downloaded file failed checksum verification - aborting.
+        del /f /q "%PYTHON_INSTALLER%" >nul 2>&1
+        exit /b 1
+    )
 )
+
 echo     Installing Python %PYTHON_VERSION% silently (per-user)...
-"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=1 Shortcuts=0 AssociateFiles=0 TargetDir="%PYTHON_INSTALL_DIR%"
+"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Shortcuts=0 AssociateFiles=0 InstallDir="%PYTHON_INSTALL_DIR%"
 if errorlevel 1 ( exit /b 1 )
 if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
-:: make python available to this session (and to the app) immediately
 set "PATH=%PYTHON_INSTALL_DIR%;%PATH%"
 exit /b 0
+
+:: Verify a downloaded files SHA256 against an expected value.
+:verify_sha256
+set "VERIFY_FILE=%~1"
+set "VERIFY_EXPECTED=%~2"
+if not exist "%VERIFY_FILE%" ( exit /b 1 )
+set "VERIFY_ACTUAL="
+for /f "delims=" %%H in ('powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath '%VERIFY_FILE%' -Algorithm SHA256).Hash" 2^>nul') do set "VERIFY_ACTUAL=%%H"
+if not defined VERIFY_ACTUAL ( exit /b 1 )
+if /i "%VERIFY_ACTUAL%"=="%VERIFY_EXPECTED%" ( exit /b 0 )
+exit /b 1
 
 :: Download helper - tries curl (bundled with Win10+), falls back to PowerShell.
 :download

--- a/install.bat
+++ b/install.bat
@@ -186,15 +186,18 @@ for /f "delims=" %%P in ('py -3 -c "import sys; sys.version_info >= (%MIN_PYTHON
 if defined PY_CMD goto :prompt_add_path
 
 :: 2) Check `python` on PATH (skipping WindowsApps Store execution alias)
-set "PY_WHERE="
-for /f "delims=" %%W in ('where python 2^>nul') do if not defined PY_WHERE set "PY_WHERE=%%W"
-if defined PY_WHERE (
-    echo !PY_WHERE! | findstr /i "WindowsApps" >nul 2>&1
-    if errorlevel 1 (
-        for /f "delims=" %%P in ('python -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=python"
-        if defined PY_CMD exit /b 0
+set "PY_CMD="
+for /f "delims=" %%W in ('where python 2^>nul') do (
+    if not defined PY_CMD (
+        echo %%W | findstr /i "WindowsApps" >nul 2>&1
+        if errorlevel 1 (
+            for /f "delims=" %%P in ('"%%W" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do (
+                set "PY_CMD=%%W"
+            )
+        )
     )
 )
+if defined PY_CMD exit /b 0
 
 :: 3) Check Windows Registry (finds official installs not added to PATH)
 for /f "tokens=2*" %%A in ('reg query "HKCU\Software\Python\PythonCore" /s /v InstallPath 2^>nul ^| findstr /i "REG_SZ"') do (

--- a/install.bat
+++ b/install.bat
@@ -73,6 +73,7 @@ echo.
 :: Clone OwO-Dusk repo.
 if exist "%INSTALL_DIR%" (
     echo [^!] Folder "%INSTALL_DIR%" already exists.
+    set "CONFIRM="
     set /p CONFIRM="    Re-clone and overwrite? [y/N]: "
     if /i "!CONFIRM!"=="y" (
         echo "%INSTALL_DIR%" | findstr /i "\owo-dusk" >nul 2>&1
@@ -173,7 +174,7 @@ if not exist "%GIT_INSTALL_DIR%\cmd\git.exe" ( exit /b 1 )
 set "PATH=%GIT_INSTALL_DIR%\cmd;%PATH%"
 
 :: Permanently update User PATH in Windows Registry
-powershell.exe -NoProfile -NonInteractive -Command "$p = [Environment]::GetEnvironmentVariable('PATH', 'User'); if ($p -notlike '*%GIT_INSTALL_DIR%\cmd*') { [Environment]::SetEnvironmentVariable('PATH', '%GIT_INSTALL_DIR%\cmd;' + $p, 'User') }"
+powershell.exe -NoProfile -NonInteractive -Command "$p = [Environment]::GetEnvironmentVariable('PATH', 'User'); if ($p -notlike '*' + $env:GIT_INSTALL_DIR + '\cmd*') { [Environment]::SetEnvironmentVariable('PATH', $env:GIT_INSTALL_DIR + '\cmd;' + $p, 'User') }"
 
 exit /b 0
 
@@ -243,6 +244,7 @@ set "PY_DIR=!PY_DIR:~0,-1!"
 echo !PATH! | findstr /i /c:"!PY_DIR!" >nul 2>&1
 if errorlevel 1 (
     echo [^!] Found Python at "!PY_CMD!", but its directory is not in PATH.
+    set "ADD_PATH_CHOICE="
     set /p ADD_PATH_CHOICE="    Add "!PY_DIR!" to current session PATH? [y/N]: "
     if /i "!ADD_PATH_CHOICE!"=="y" (
         set "PATH=!PY_DIR!;!PATH!"
@@ -263,7 +265,6 @@ if exist "%PYTHON_INSTALLER%" (
 
 if "%PY_HAVE_GOOD_INSTALLER%"=="0" (
     echo     Downloading Python %PYTHON_VERSION%...
-    :: https://www.python.org/ftp/python/3.13.15/python-3.13.15-amd64.exe
     call :download "https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-amd64.exe" "%PYTHON_INSTALLER%"
     if errorlevel 1 ( exit /b 1 )
     call :verify_sha256 "%PYTHON_INSTALLER%" "%PYTHON_SHA256%"
@@ -281,23 +282,21 @@ if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
 set "PATH=%PYTHON_INSTALL_DIR%;%PATH%"
 exit /b 0
 
-:: Verify a downloaded files SHA256 against an expected value.
+:: Verify a downloaded file's SHA256 against an expected value.
 :verify_sha256
 set "VERIFY_FILE=%~1"
-set "VERIFY_EXPECTED=%~2"
+set "EXPECTED_HASH=%~2"
 if not exist "%VERIFY_FILE%" ( exit /b 1 )
-set "VERIFY_ACTUAL="
-for /f "delims=" %%H in ('powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath '%VERIFY_FILE%' -Algorithm SHA256).Hash" 2^>nul') do set "VERIFY_ACTUAL=%%H"
-if not defined VERIFY_ACTUAL ( exit /b 1 )
-if /i "%VERIFY_ACTUAL%"=="%VERIFY_EXPECTED%" ( exit /b 0 )
-exit /b 1
+powershell.exe -NoProfile -NonInteractive -Command "if ((Get-FileHash -LiteralPath $env:VERIFY_FILE -Algorithm SHA256).Hash.ToLower() -ne $env:EXPECTED_HASH.ToLower()) { exit 1 }" 2>nul
+if errorlevel 1 ( exit /b 1 )
+exit /b 0
 
 :: Download helper - tries curl (bundled with Win10+), falls back to PowerShell.
 :download
 set "DL_URL=%~1"
 set "DL_OUT=%~2"
-curl.exe -fSL --retry 3 -o "%DL_OUT%" "%DL_URL%" >nul 2>&1
+curl.exe -fSL --max-time 300 --retry 3 -o "%DL_OUT%" "%DL_URL%" >nul 2>&1
 if not errorlevel 1 ( exit /b 0 )
-powershell.exe -NoProfile -NonInteractive -Command "Invoke-WebRequest -UseBasicParsing -Uri '%DL_URL%' -OutFile '%DL_OUT%'" >nul 2>&1
+powershell.exe -NoProfile -NonInteractive -Command "Invoke-WebRequest -UseBasicParsing -TimeoutSec 300 -Uri $env:DL_URL -OutFile $env:DL_OUT" >nul 2>&1
 if not errorlevel 1 ( exit /b 0 )
 exit /b 1

--- a/install.bat
+++ b/install.bat
@@ -84,6 +84,12 @@ if exist "%INSTALL_DIR%" (
         )
         echo     If owo-dusk is currently running, please close it first.
         rmdir /s /q "%INSTALL_DIR%"
+        if exist "%INSTALL_DIR%" (
+            :: Windows prevents deletion of files that are active
+            echo [x] Failed to delete existing directory. Close any open files/terminals and try again.
+            pause
+            exit /b 1
+        )
     ) else (
         echo [*] Skipping clone - using existing directory.
         goto :run_setup

--- a/install.bat
+++ b/install.bat
@@ -8,34 +8,78 @@ echo  owo-dusk Installer - Windows
 echo  ==============================
 echo.
 
-:: check git
-git --version >nul 2>&1
-if %ERRORLEVEL% neq 0 (
-    echo [!] git is not installed or not in PATH.
-    echo     Download it from: https://git-scm.com/download/win
-    echo     Make sure to check "Add git to PATH" during install.
-    pause
-    exit /b 1
-)
+set "OWO_REPO_URL=https://github.com/owo-dusk/owo-dusk.git"
+set "INSTALL_DIR=%USERPROFILE%\Desktop\owo-dusk"
 
-:: check python
-python --version >nul 2>&1
-if %ERRORLEVEL% neq 0 (
-    echo [!] Python is not installed or not in PATH.
-    echo     Download it from: https://www.python.org/downloads/
-    echo     Make sure to check "Add Python to PATH" during install.
-    pause
-    exit /b 1
-)
+set "GIT_VERSION=2.55.0.windows.3"
+set "GIT_PORTABLE_ASSET=PortableGit-2.55.0.3-64-bit.7z.exe"
+set "GIT_INSTALL_DIR=%LocalAppData%\Programs\Git"
+set "GIT_CMD="
 
-echo [*] git and Python found. Continuing...
+set "PYTHON_VERSION=3.12.8"
+set "PYTHON_INSTALL_DIR=%LocalAppData%\Programs\Python\Python312"
+set "PY_CMD="
+
+:: ---------------------------------------------------------------
+:: 1) Make sure Git is available. An existing install is reused;
+::    otherwise a portable Git is downloaded and extracted silently
+::    (per-user, no admin rights required).
+:: ---------------------------------------------------------------
+echo [*] Checking for Git...
+call :find_git
+if errorlevel 1 (
+    echo [^!] Git not found. Installing portable Git %GIT_VERSION% silently...
+    call :install_git
+    if errorlevel 1 (
+        echo [x] Failed to install Git automatically.
+        echo     Please install it manually from https://git-scm.com/download/win
+        echo     and make sure "Add git to PATH" is checked.
+        pause
+        exit /b 1
+    )
+    call :find_git
+    if errorlevel 1 (
+        echo [x] Git is still not usable, cannot continue.
+        pause
+        exit /b 1
+    )
+)
+echo [*] Using Git: "%GIT_CMD%"
 echo.
 
-set INSTALL_DIR=%USERPROFILE%\Desktop\owo-dusk
+:: ---------------------------------------------------------------
+:: 2) Make sure Python 3.12 is available. An existing 3.12.x is
+::    reused; otherwise Python %PYTHON_VERSION% is downloaded and
+::    installed silently (per-user, no admin rights required).
+:: ---------------------------------------------------------------
+echo [*] Checking for Python %PYTHON_VERSION%...
+call :find_python
+if errorlevel 1 (
+    echo [^!] Python %PYTHON_VERSION% not found. Installing it silently...
+    call :install_python
+    if errorlevel 1 (
+        echo [x] Failed to install Python automatically.
+        echo     Please install it manually from https://www.python.org/downloads/
+        echo     and make sure "Add Python to PATH" is checked.
+        pause
+        exit /b 1
+    )
+    call :find_python
+    if errorlevel 1 (
+        echo [x] Python is still not usable, cannot continue.
+        pause
+        exit /b 1
+    )
+)
+echo [*] Using Python: "%PY_CMD%"
+"%PY_CMD%" --version
+echo.
 
-::clone
+:: ---------------------------------------------------------------
+:: 3) Clone (or reuse) the repository
+:: ---------------------------------------------------------------
 if exist "%INSTALL_DIR%" (
-    echo [!] Folder "%INSTALL_DIR%" already exists.
+    echo [^!] Folder "%INSTALL_DIR%" already exists.
     set /p CONFIRM="    Re-clone and overwrite? [y/N]: "
     if /i "!CONFIRM!"=="y" (
         rmdir /s /q "%INSTALL_DIR%"
@@ -46,30 +90,33 @@ if exist "%INSTALL_DIR%" (
 )
 
 echo [*] Cloning owo-dusk to your Desktop...
-git clone https://github.com/echoquill/owo-dusk.git "%INSTALL_DIR%"
-if %ERRORLEVEL% neq 0 (
-    echo [!] Failed to clone repository. Check your internet connection.
+"%GIT_CMD%" clone --depth 1 "%OWO_REPO_URL%" "%INSTALL_DIR%"
+if errorlevel 1 (
+    echo [^!] Failed to clone repository. Check your internet connection.
     pause
     exit /b 1
 )
 
 :run_setup
-::setup
 cd /d "%INSTALL_DIR%"
 echo.
 echo [*] Running setup.py...
-python setup.py
-if %ERRORLEVEL% neq 0 (
-    echo [!] setup.py exited with an error.
+"%PY_CMD%" setup.py
+if errorlevel 1 (
+    echo [^!] setup.py exited with an error.
     pause
     exit /b 1
 )
 
 :: launch
 echo.
-echo [OK] Setup complete! Launching owo-dusk...
+echo [OK] Setup complete^! Launching owo-dusk...
 echo.
-python uwu.py
+if defined OWO_INSTALLER_SKIP_LAUNCH (
+    echo [i] OWO_INSTALLER_SKIP_LAUNCH is set - skipping the app launch.
+) else (
+    "%PY_CMD%" uwu.py
+)
 
 :: re-run command
 echo.
@@ -79,3 +126,78 @@ echo    cd "%INSTALL_DIR%" ^&^& python uwu.py
 echo -------------------------------------------------------
 echo.
 pause
+exit /b 0
+
+:: ================================================================
+:: Subroutines
+:: ================================================================
+
+:: Try to locate an existing Git install; sets GIT_CMD on success.
+:find_git
+set "GIT_CMD="
+git --version >nul 2>&1
+if not errorlevel 1 ( set "GIT_CMD=git" & exit /b 0 )
+if exist "%ProgramFiles%\Git\cmd\git.exe" ( set "GIT_CMD=%ProgramFiles%\Git\cmd\git.exe" & set "PATH=%ProgramFiles%\Git\cmd;%PATH%" & exit /b 0 )
+if exist "%GIT_INSTALL_DIR%\cmd\git.exe" ( set "GIT_CMD=%GIT_INSTALL_DIR%\cmd\git.exe" & set "PATH=%GIT_INSTALL_DIR%\cmd;%PATH%" & exit /b 0 )
+exit /b 1
+
+:: Download and extract a portable Git (no admin rights required).
+:install_git
+set "GIT_INSTALLER=%TEMP%\%GIT_PORTABLE_ASSET%"
+if not exist "%GIT_INSTALLER%" (
+    echo     Downloading %GIT_PORTABLE_ASSET%...
+    call :download "https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%/%GIT_PORTABLE_ASSET%" "%GIT_INSTALLER%"
+    if errorlevel 1 ( exit /b 1 )
+)
+echo     Extracting to "%GIT_INSTALL_DIR%"...
+if not exist "%GIT_INSTALL_DIR%" mkdir "%GIT_INSTALL_DIR%"
+"%GIT_INSTALLER%" -o"%GIT_INSTALL_DIR%" -y >nul 2>&1
+if errorlevel 1 ( exit /b 1 )
+if not exist "%GIT_INSTALL_DIR%\cmd\git.exe" ( exit /b 1 )
+:: make git available to this session (and to pip subprocesses) immediately
+set "PATH=%GIT_INSTALL_DIR%\cmd;%PATH%"
+exit /b 0
+
+:: Try to locate a usable Python 3.12.x; sets PY_CMD on success.
+:find_python
+set "PY_CMD="
+:: 1) the py launcher, if a 3.12 is registered
+for /f "delims=" %%P in ('py -3.12 -c "import sys;print(sys.executable)" 2^>nul') do set "PY_CMD=%%P"
+if defined PY_CMD ( exit /b 0 )
+:: 2) a bare `python` that is already a 3.12.x
+set "PY_VER="
+for /f "tokens=2 delims= " %%v in ('python --version 2^>^&1') do set "PY_VER=%%v"
+if defined PY_VER (
+    echo !PY_VER! | findstr /b "3.12." >nul 2>&1
+    if not errorlevel 1 ( set "PY_CMD=python" & exit /b 0 )
+)
+:: 3) common install locations
+if exist "%PYTHON_INSTALL_DIR%\python.exe" ( set "PY_CMD=%PYTHON_INSTALL_DIR%\python.exe" & set "PATH=%PYTHON_INSTALL_DIR%;%PATH%" & exit /b 0 )
+if exist "%ProgramFiles%\Python312\python.exe" ( set "PY_CMD=%ProgramFiles%\Python312\python.exe" & set "PATH=%ProgramFiles%\Python312;%PATH%" & exit /b 0 )
+exit /b 1
+
+:: Download and silently install Python %PYTHON_VERSION% per-user (no admin).
+:install_python
+set "PYTHON_INSTALLER=%TEMP%\python-%PYTHON_VERSION%-amd64.exe"
+if not exist "%PYTHON_INSTALLER%" (
+    echo     Downloading Python %PYTHON_VERSION%...
+    call :download "https://www.python.org/ftp/python/%PYTHON_VERSION%/python-%PYTHON_VERSION%-amd64.exe" "%PYTHON_INSTALLER%"
+    if errorlevel 1 ( exit /b 1 )
+)
+echo     Installing Python %PYTHON_VERSION% silently (per-user)...
+"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Shortcuts=0 AssociateFiles=0 InstallDir="%PYTHON_INSTALL_DIR%"
+if errorlevel 1 ( exit /b 1 )
+if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
+:: make python available to this session (and to the app) immediately
+set "PATH=%PYTHON_INSTALL_DIR%;%PATH%"
+exit /b 0
+
+:: Download helper - tries curl (bundled with Win10+), falls back to PowerShell.
+:download
+set "DL_URL=%~1"
+set "DL_OUT=%~2"
+curl.exe -fSL --retry 3 -o "%DL_OUT%" "%DL_URL%" >nul 2>&1
+if not errorlevel 1 ( exit /b 0 )
+powershell.exe -NoProfile -NonInteractive -Command "Invoke-WebRequest -UseBasicParsing -Uri '%DL_URL%' -OutFile '%DL_OUT%'" >nul 2>&1
+if not errorlevel 1 ( exit /b 0 )
+exit /b 1

--- a/install.bat
+++ b/install.bat
@@ -131,6 +131,7 @@ echo    cd "%INSTALL_DIR%" ^&^& "%PY_CMD%" uwu.py
 echo -------------------------------------------------------
 echo.
 pause
+endlocal & set "PATH=%PATH%"
 exit /b 0
 
 :: Try to locate an existing Git install; sets GIT_CMD on success.
@@ -202,14 +203,14 @@ if defined PY_CMD exit /b 0
 
 :: 3) Check Windows Registry (finds official installs not added to PATH)
 for /f "tokens=2*" %%A in ('reg query "HKCU\Software\Python\PythonCore" /s /v InstallPath 2^>nul ^| findstr /i "REG_SZ"') do (
-    if exist "%%Bpython.exe" (
-        for /f "delims=" %%P in ('"%%Bpython.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%Bpython.exe"
+    if exist "%%B\python.exe" (
+        for /f "delims=" %%P in ('"%%B\python.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%B\python.exe"
         if defined PY_CMD goto :prompt_add_path
     )
 )
 for /f "tokens=2*" %%A in ('reg query "HKLM\Software\Python\PythonCore" /s /v InstallPath 2^>nul ^| findstr /i "REG_SZ"') do (
-    if exist "%%Bpython.exe" (
-        for /f "delims=" %%P in ('"%%Bpython.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%Bpython.exe"
+    if exist "%%B\python.exe" (
+        for /f "delims=" %%P in ('"%%B\python.exe" -c "import sys; sys.version_info >= (%MIN_PYTHON_VERSION:.=, %) and print(sys.executable)" 2^>nul') do set "PY_CMD=%%B\python.exe"
         if defined PY_CMD goto :prompt_add_path
     )
 )

--- a/install.bat
+++ b/install.bat
@@ -268,7 +268,7 @@ if "%PY_HAVE_GOOD_INSTALLER%"=="0" (
 )
 
 echo     Installing Python %PYTHON_VERSION% silently (per-user)...
-"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=0 Shortcuts=0 AssociateFiles=0 InstallDir="%PYTHON_INSTALL_DIR%"
+"%PYTHON_INSTALLER%" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0 Include_launcher=1 Shortcuts=0 AssociateFiles=0 TargetDir="%PYTHON_INSTALL_DIR%"
 if errorlevel 1 ( exit /b 1 )
 if not exist "%PYTHON_INSTALL_DIR%\python.exe" ( exit /b 1 )
 set "PATH=%PYTHON_INSTALL_DIR%;%PATH%"


### PR DESCRIPTION
## Summary

`install.bat` previously **required** Git and Python to already be installed — if either was missing it just printed download links and exited. This PR makes the installer fully automatic: when Git and/or Python are missing, they are **downloaded and installed silently, per-user, with no admin rights required**, and the fresh binaries are used immediately for the clone, `setup.py`, and app launch.

## What changed

- **Auto-install Git** — if no usable Git is found, downloads **portable Git** (`PortableGit-2.55.0.3-64-bit.7z.exe`) and extracts it to `%LocalAppData%\Programs\Git` (no UAC/admin needed), then uses its `git.exe` directly.
- **Auto-install Python 3.12.8** — if no Python 3.12.x is found, downloads `python-3.12.8-amd64.exe` from python.org and installs it silently **per-user** (`InstallAllUsers=0` → `%LocalAppData%\Programs\Python\Python312`, no admin), with `PrependPath=1` so it is also added to the user PATH for future sessions.
- **Uses the installed binaries** — the script invokes the exact `python.exe` / `git.exe` full paths for clone, `setup.py`, and `uwu.py`, rather than relying on `PATH` guesses. It also adds their folders to the current session's `PATH`, which is required by pip to clone `discord.py-self @ git+...` from `requirements.txt`.
- **Smart detection** — reuses an existing install when compatible:
  - Git: `git` on PATH → `%ProgramFiles%\Git` → `%LocalAppData%\Programs\Git`
  - Python: `py -3.12` launcher → `python` already on 3.12.x → `%LocalAppData%\Programs\Python\Python312` → `%ProgramFiles%\Python312`
- **Canonical repo URL** — clone URL updated from `echoquill/owo-dusk.git` to `https://github.com/owo-dusk/owo-dusk.git` (the repo was renamed; the old URL only works via redirect), plus a shallow `--depth 1` clone for faster installs.
- **`OWO_INSTALLER_SKIP_LAUNCH` env var** — set it to skip launching `uwu.py` (useful for scripting/CI and for installs where you just want the setup done).
- **Cosmetic fix** — with `EnableDelayedExpansion`, the `[!]` warning prefixes were being mangled to `[]`; exclamation marks are now caret-escaped so `[!]` renders correctly.

## Fallbacks

If either automated install fails (e.g. blocked download), the script still prints the manual install instructions and exits — same guidance as before, only after the automatic attempt.

## Tested

Verified end-to-end on a machine with **neither Git nor Python 3.12** available:

1. Script downloaded + installed portable Git `2.55.0.windows.3` and Python `3.12.8` (per-user), confirmed via `git --version` / `Python 3.12.8`.
2. Cloned the repo with the freshly installed Git, ran `setup.py` with the freshly installed Python — `requirements.txt` (incl. `discord.py-self` from git) and `numpy/pillow` installed as `cp312` wheels into Python 3.12.8.
3. Re-ran the script to confirm it detects and reuses the existing installs instead of reinstalling.

## Notes

- The Python installer's `PrependPath=1` puts 3.12.8 at the front of the *user* PATH when an install happens — this is intended (it's what "sets up Python 3.12.8" means), but worth knowing if you already rely on a different default Python.
- Portions of this file are original EchoQuill/GPL-3.0 code; the derivation keeps the same license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer detects existing Git and Python 3.12+ installations.
  * Missing prerequisites can be downloaded and installed automatically for the current user.
  * Added an option to skip launching the application after setup.
  * Installer supports configurable repository and tool locations.
  * Updates the current session’s PATH for newly installed tools.

* **Bug Fixes**
  * Improved setup and launching across different Git and Python installation locations.
  * Added clearer feedback when downloads or dependency setup fail.
  * Improved fallback handling when downloading required components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->